### PR TITLE
Traffic light instructions revision

### DIFF
--- a/book/opmanual_duckietown/02-duckietown-preliminaries-layers.md
+++ b/book/opmanual_duckietown/02-duckietown-preliminaries-layers.md
@@ -24,7 +24,7 @@ Regardless of the geometry of the roads (straight, curve, intersections), roads 
 
 ## Signals Layer {#dt-ops-signals-layer status=ready}
 
-The signals layer contains all the [signs](#dt-ops-city-traffic-signs) and other functional objects (e.g., [traffic lights](#traffic-light-assembly)) that sit on top of the mats. Objects are functional when they enable some behavior for the Duckiebots. For example, traffic signs are functional because they inform Duckiebots at intersections where they are and what should they look out for to know when to drive on.
+The signals layer contains all the [signs](#dt-ops-city-traffic-signs) and other functional objects that sit on top of the mats (e.g., traffic lights, watchtowers, etc.). Objects are functional when they enable some behavior for the Duckiebots. For example, traffic signs are functional because they inform Duckiebots at intersections where they are and what should they look out for to know when to drive on.
 
 ## Non-functional elements {#dt-ops-non-functional-layer status=ready}
 

--- a/book/opmanual_duckietown/04-duckietown-appearance-specifications.md
+++ b/book/opmanual_duckietown/04-duckietown-appearance-specifications.md
@@ -364,7 +364,7 @@ Street name signs should never be perpendicular to the road - they are too big a
 
 ## Traffic Lights {#traffic-light-app-spec status=ready}
 
-The assembly procedure for building the a traffic light is found in [](#traffic-light-assembly).
+The assembly procedure for building traffic lights can be found in [](#traffic-light-assembly-18).
 
 ### Placement
 
@@ -376,4 +376,4 @@ The Raspberry Pi should sit on a pole that is based at the corner of the tile ou
 
 -->
 
-The computational stack of the traffic light should be mounted in the appropriate housing outside the allowable driving region. The cabling should be housed in the appropriate structure as detailed in [](#traffic-light-assembly). The traffic light pillar stands should be positioned in such a way that the embedded traffic sign stands respect the above specifications for traffic light stands.
+The computational stack of the traffic light should be mounted in the appropriate housing outside the allowable driving region. The cabling should be housed in the appropriate structure as detailed in [](#traffic-light-assembly-18). The traffic light pillar stands should be positioned in such a way that the embedded traffic sign stands respect the above specifications for traffic light stands.

--- a/book/opmanual_duckietown/10_duckietown_assembly.md
+++ b/book/opmanual_duckietown/10_duckietown_assembly.md
@@ -16,7 +16,7 @@ You can refer to these resources for assembly tips on the various city elements:
 
 - [Roads assembly](#dt-ops-tiles);
 - [Traffic signs assembly](#dt-ops-city-traffic-signs);
-- [Traffic lights assembly](#traffic-light-assembly);
+- [Traffic lights assembly](#traffic-light-assembly-18);
 
 Once you are done building your city, populate it with tons of Duckies!
 

--- a/book/opmanual_duckietown/13_traffic_lights_assembly_18.md
+++ b/book/opmanual_duckietown/13_traffic_lights_assembly_18.md
@@ -1,21 +1,17 @@
-# Assembly - Traffic Light {#traffic-light-assembly-18 status=ready}
+# Assembly - Traffic Light `DT18-TL` {#traffic-light-assembly-18 status=ready}
+
 <div class='requirements' markdown="1">
 
-Requires: Traffic light components.
+Requires: `DT18-TL` Traffic light components (can be sourced from the [Duckietown project shop](https://get.duckietown.com/collections/the-duckietown-city/products/smart-traffic-light?variant=32311801413771))
 
 Requires: An appropriately [configured SD-card](https://docs.duckietown.org/daffy/opmanual_duckiebot/out/setup_duckiebot.html).
 
-Requires: Tools: (strong) wood glue or hot glue gun, tape, double-sided tape.
+Requires: Tools: wood glue or hot glue gun.
 
-Result: Traffic light.    
-</div>  
+Result: Traffic light in configuration `DT18-TL`.
+</div>
 
-
-<!--
-: fix link above with proper inter book link.
--->
-
-Traffic lights are useful to coordinate traffic at intersections. They can be used at three or four way intersections. Hardware wise, traffic lights are essentially "Duckiebots without wheels", and a beautiful different chassis.
+Traffic lights can be used to coordinate traffic at three or four way intersections in Duckietown. Hardware wise, traffic lights are essentially "Duckiebots without wheels", and a beautiful different chassis.
 
 Reminder: for traffic lights to be recognized by Duckiebots, appropriate signage must be placed at intersections (traffic light traffic sign instead of stop sign).
 
@@ -29,14 +25,9 @@ Traffic lights are crucial parts in modern cities. We rely on them to have well-
 
 -->
 
-Traffic lights are composed of two wooden boxes on the diagonal direction of an intersection. One of them is equipped with the computational stack and connection to the a camera.
+Traffic lights are composed of two supports connected by an overhanging tube. They are intended to be placed on the diagonal direction of an intersection. One of the supports is equipped with the computational stack and an overseeing camera.
 
-<!--
-TODO: Add a photo of one intersection with a **new model** traffic light (as in pics below).
-
-Traffic lights node are expected to launch whenever they turn on.
-
--->
+Traffic lights can double-up as [watchtowers](+opmanual_autolab#watchtower-hardware-assembly-WT18) when upgrading a Duckietown to [Duckietown Autolab](+opmanual_autolab#book). 
 
 ## Assembly of the traffic light parts
 
@@ -400,19 +391,23 @@ Use the spacers and the screws to mount the Raspberry Pi on the Raspberry Pi gro
 Plug the shield on top of the Raspberry Pi.  
 Insert the SD card.  
 Connect the LED cable to the shield.  
+
+<div figure-id="fig:TL-19">
+<img src="STEP_18_cropped.png" style="width: 80%"/>
+</div>
+
+
 Connect the Ethernet cable.  
 Connect the USB cable.
-<div figure-id="fig:TL-19">
-<img src="images/TL-19.jpg" style="width: 80%"/>
-<figcaption>
-</figcaption>
-</div>  
+
+
+
 If done correctly the LEDs should be on.  
+
 <div figure-id="fig:TL-20">
 <img src="images/TL-20.jpg" style="width: 80%"/>
-<figcaption>
-</figcaption>
 </div>  
+
 Close the ground module with the case.    
 
 <div figure-id="fig:TL-21">

--- a/book/opmanual_duckietown/13_traffic_lights_assembly_18.md
+++ b/book/opmanual_duckietown/13_traffic_lights_assembly_18.md
@@ -1,0 +1,535 @@
+# Assembly - Traffic Light {#traffic-light-assembly-18 status=ready}
+<div class='requirements' markdown="1">
+
+Requires: Traffic light components.
+
+Requires: An appropriately [configured SD-card](https://docs.duckietown.org/daffy/opmanual_duckiebot/out/setup_duckiebot.html).
+
+Requires: Tools: (strong) wood glue or hot glue gun, tape, double-sided tape.
+
+Result: Traffic light.    
+</div>  
+
+
+<!--
+: fix link above with proper inter book link.
+-->
+
+Traffic lights are useful to coordinate traffic at intersections. They can be used at three or four way intersections. Hardware wise, traffic lights are essentially "Duckiebots without wheels", and a beautiful different chassis.
+
+Reminder: for traffic lights to be recognized by Duckiebots, appropriate signage must be placed at intersections (traffic light traffic sign instead of stop sign).
+
+This section describes the physical assembly and installation of traffic lights.  
+
+## Overview
+
+<!--
+
+Traffic lights are crucial parts in modern cities. We rely on them to have well-organized traffic. While autonomous cars could communicate with each other through so many different kinds of protocols, humans can't. Unless you are a terminator, or a RoboCop, or Neo. In the near future where autonomous cars drive with human drivers, we still need the help of traffic lights.
+
+-->
+
+Traffic lights are composed of two wooden boxes on the diagonal direction of an intersection. One of them is equipped with the computational stack and connection to the a camera.
+
+<!--
+TODO: Add a photo of one intersection with a **new model** traffic light (as in pics below).
+
+Traffic lights node are expected to launch whenever they turn on.
+
+-->
+
+## Assembly of the traffic light parts
+
+This section shows how to assemble the components from the laser cut traffic light parts.
+
+Warning: The small parts with the hole in the middle, i.e., the ones in the left of [](#fig:G-1), are not all equal. Some have a round hole, others a polygonal hole. Double check you are using the right ones in the process (compare with the pics).
+
+All parts should be glued together as showed in the pictures for enhanced structural stability.
+
+### Tube holder with big ground plate  
+
+<div figure-id="fig:G-1">
+<img src="images/G-1.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G-2">
+<img src="images/G-2.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G-3">
+<img src="images/G-3.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G-4">
+<img src="images/G-4.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G-5">
+<img src="images/G-5.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G-6">
+<img src="images/G-6.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>    
+
+<div figure-id="fig:G-7">
+<img src="images/G-7.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G-8">
+<img src="images/G-8.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+
+### Tube holder with small ground plate
+
+<div figure-id="fig:G2-1">
+<img src="images/G2-1.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G2-2">
+<img src="images/G2-2.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G2-3">
+<img src="images/G2-3.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G2-4">
+<img src="images/G2-4.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G2-5">
+<img src="images/G2-5.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G2-6">
+<img src="images/G2-6.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:G2-7">
+<img src="images/G2-7.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+
+
+
+### Traffic light LED housing
+
+<div figure-id="fig:L-1">
+<img src="images/L-1.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:L-2">
+<img src="images/L-2.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:L-3">
+<img src="images/L-3.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:L-4">
+<img src="images/L-4.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:L-5">
+<img src="images/L-5.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:L-6">
+<img src="images/L-6.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+
+
+
+### Ground module cover
+<div figure-id="fig:C-01">
+<img src="images/C-01.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:C-02">
+<img src="images/C-02.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+
+
+### Joint module
+
+<div figure-id="fig:J-1">
+<img src="images/J-1.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:J-2">
+<img src="images/J-2.jpg" style="width: 40%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:J-3">
+<img src="images/J-3.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:J-4">
+<img src="images/J-4.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:J-5">
+<img src="images/J-5.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:J-6">
+<img src="images/J-6.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:J-7">
+<img src="images/J-7.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:J-8">
+<img src="images/J-8.jpg" style="width: 50%"/>
+<figcaption>
+</figcaption>
+</div>  
+
+## Components of the traffic light {#tl-mat}
+
+Now that you have assembled the traffic light chassis, you are ready to add the electronics.
+
+<div figure-id="fig:tl_components">
+<img src="images/TL-01.jpg" style="width: 100%"/>
+<figcaption>
+Parts of a traffic light needed to complete these instructions.
+</figcaption>
+</div>
+
+
+
+These components are needed for one traffic light:
+
+* Tube holder with big ground plate
+* Tube holder with small ground plate (Duckietown)
+* Cable with soldered LED strip
+* Joint module (2x)
+* Traffic light LED housing
+* Raspberry Pi base plate
+* Ground module cover (Duckietown)
+* Camera mount
+* Camera mount cover
+* Short tube
+* Medium tube (2x)
+* Long tube with hole at the side
+* Raspberry Pi
+* Raspberry Pi shield
+* M2.5x10 MF Nylon spacers (8x)
+* M2.5x8 Nylon screws (4x)
+* SD card with Duckietown software
+* USB cable
+* Ethernet cable
+
+Additionally, the traffic light structure can host:
+
+* Traffic sign stands (4x)
+* Traffic sign stand supports (4x).
+
+
+## Assembling the Traffic Light
+
+
+
+### Put the LEDs into the housing
+
+Bend the LED strip at an angle to reduce the chance that the exposed soldered wires short. The exposed part of the wires should **not** be in contact, **especially** when turning on the power.
+
+Warning: the actual traffic light in your hands might vary slightly from the pictures above. In particular, the electrical cables could have different colors or be soldered in different positions. Take note of what each color cable is soldered to, as same will go go with same on the other end.
+
+
+<div figure-id="fig:L-0">
+<img src="images/L-0.png" style="width: 80%"/>
+<figcaption>
+Bended LED strip cable
+</figcaption>
+</div>
+
+<div figure-id="fig:TL-02">
+<img src="images/TL-02.jpg" style="width: 80%"/>
+<figcaption>
+Cable with soldered LED strip LED housing
+</figcaption>
+</div>  
+<div figure-id="fig:TL-03">
+<img src="images/TL-03.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+Carefully push the LEDs into the designated holes.
+<div figure-id="fig:TL-05">
+<img src="images/TL-05.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:TL-04">
+<img src="images/TL-04.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+Fix the LEDs with some tape, don't use glue.
+<div figure-id="fig:TL-06">
+<img src="images/TL-06.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>
+
+### Connect the tubes
+
+
+<div figure-id="fig:TL-07">
+<img src="images/TL-07.jpg" style="width: 80%"/>
+<figcaption>
+Medium tubes and LED housing.
+</figcaption>
+</div>  
+Stick the tubes into the sides of the LED housing and pull the cable through one side.
+<div figure-id="fig:TL-08">
+<img src="images/TL-08.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+Add the joint modules on the side of the tube without the cable.  
+<div figure-id="fig:TL-09">
+<img src="images/TL-09.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+
+<div figure-id="fig:TL-10">
+<img src="images/TL-10.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>    
+Mount the other joint module on the long tube, such that it aligns with the hole.
+
+You can add additional tape under the joint modules to prevent them to slip down.
+<div figure-id="fig:H-1">
+<img src="images/H-1.png" style="width: 80%"/>
+<figcaption>
+Fully assembled traffic light.
+</figcaption>
+</div>
+
+
+<div figure-id="fig:TL-11">
+<img src="images/TL-11.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:TL-12">
+<img src="images/TL-12.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:TL-13">
+<img src="images/TL-13.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+Pull the cable through longer tube and stick the tube into the joint module.
+<div figure-id="fig:TL-14">
+<img src="images/TL-14.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:TL-15">
+<img src="images/TL-15.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+Put the tubes into the tube holders.  
+
+<div figure-id="fig:TL-16">
+<img src="images/TL-16.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:TL-17">
+<img src="images/TL-17.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>
+
+
+### Connect the Raspberry Pi
+
+
+Use the spacers and the screws to mount the Raspberry Pi on the Raspberry Pi ground plate as shown in [](#fig:TL-18).
+
+<div figure-id="fig:TL-18">
+<img src="images/TL-18.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+Plug the shield on top of the Raspberry Pi.  
+Insert the SD card.  
+Connect the LED cable to the shield.  
+Connect the Ethernet cable.  
+Connect the USB cable.
+<div figure-id="fig:TL-19">
+<img src="images/TL-19.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+If done correctly the LEDs should be on.  
+<div figure-id="fig:TL-20">
+<img src="images/TL-20.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+Close the ground module with the case.    
+
+<div figure-id="fig:TL-21">
+<img src="images/TL-21.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>
+<div figure-id="fig:TL-22">
+<img src="images/TL-22.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>
+
+### Add traffic sign stands
+<div figure-id="fig:TL-23">
+<img src="images/TL-23.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+<div figure-id="fig:TL-24">
+<img src="images/TL-24.jpg" style="width: 80%"/>
+<figcaption>
+</figcaption>
+</div>  
+
+### Fully assembled traffic light
+
+<div figure-id="fig:TL-25">
+<img src="images/TL-25.jpg" style="width: 80%"/>
+<figcaption>
+Fully assembled traffic light.
+</figcaption>
+</div>
+
+Place the traffic light at an intersection such that the LEDs are exactly in the middle and are facing each incoming lane perpendicularly.
+
+You can verify the position is correct by verifying that Duckiebots at the red stop lines can see only one light blinking, and no reflections of LEDs facing other directions.
+
+You can finally use the provided double-sided tape pads to fix the traffic light to the tiles.
+
+### SD-card image Preparation {#dt-ops-tl-prep status=ready}
+
+At hardware and software level, traffic lights are Duckiebots without wheels. In initializing the SD-card of your
+traffic light, follow the instructions [here](+opmanual_duckiebot#setup-duckiebot), with the extra step of using the
+option `--type traffic_light`. Also, WiFi configuration for traffic lights is by default not set. You can add it
+using the `--wifi` option as specified int the [instructions](+opmanual_duckiebot#setup-duckiebot).
+
+An example flashing command for a wifi connected traffic light can be:
+
+    laptop $ dts init_sd_card --hostname watchtower![XX] --country ![COUNTRY] --type traffic_light --configuration TL19 --wifi duckietown:quackquack
+
+- For Autolab users: since traffic lights are coupled to watchtowers, please use the watchtower setup:
+        hostname : watchtowerXX
+
+- However, if you just want to use it as a traffic light, use the trafficlight setup:
+        hostname : trafficlightXX
+
+- The default username and password are all the same:
+
+    Username: duckie
+    Password: quackquack
+
+Warning: For autolab users, do not change the username and password.
+
+<!--
+
+`DB17` instructions
+
+Prepare a Duckiebot image following the instructions on `DB17` Duckiebot initialization and remember to generate the new machine file.
+
+
+See setup-duckiebot
+and this chapter
+See rc-control
+
+
+`DB18` instructions {#dt-ops-tl-init status=draft}
+ write detailed instruction, verify functionality with docker infrastructure
+
+-->
+
+### Launch Traffic Lights {#dt-ops-tl-launch status=ready}
+By choosing the `robot_type` to be `traffic_light`, the blinking behaviour should happen as soon as you boot your device.
+
+If you need to manually restart the behaviour inside the `duckiebot-interface` container, you can restart the traffic light behaviour by running
+
+    duckiebot-container $ roslaunch duckiebot_interface all_drivers.launch veh:=![NAME] robot_type:=traffic_light
+
+
+<!--
+
+Semantics of LEDS {#LED-semantics status=draft}
+
+headlights: white, constant
+
+Assumption:
+
+- **20 fps** to do LED detection
+
+- 1s to decide
+
+- 3 frequencies to detect
+
+tail lights: red, **6 hz square wave**
+
+traffic light "GO" = green, **1 hz square wave**
+
+traffic light "STOP" = red, **1.5 Hz** square wave**
+
+duckie light on top, state 0 = off
+
+duckie light on top, state 1 = blue, **3 Hz, square wave**
+
+duckie light on top, state 2 = ?, **2.5 Hz square wave**
+
+duckie light on top, state 3 = ?, **2 Hz square wave**
+
+verify if this info is still up to date.
+
+-->

--- a/book/opmanual_duckietown/14_traffic_lights_assembly_21.md
+++ b/book/opmanual_duckietown/14_traffic_lights_assembly_21.md
@@ -2,7 +2,7 @@
 
 <div class='requirements' markdown="1">
 
-Requires: Material: Watchtower components. To obtain them contact info@duckietown.org.
+Requires: Material: Watchtower components. To obtain them contact info@duckietown.com.
 
 Requires: An [initialized SD-card](https://docs.duckietown.org/daffy/opmanual_autolab/out/watchtower_initialization.html) for traffic lights or Watchtowers.
 

--- a/book/opmanual_duckietown/14_traffic_lights_assembly_21.md
+++ b/book/opmanual_duckietown/14_traffic_lights_assembly_21.md
@@ -1,4 +1,4 @@
-# Assembly - Traffic Light {#traffic-light-assembly status=ready}
+# Assembly - Traffic Light {#traffic-light-assembly-21 status=beta}
 
 <div class='requirements' markdown="1">
 

--- a/book/opmanual_duckietown/images/traffic_light_18/C-01.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/C-01.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43f7ae08def4dbdf612919ffbcefd7629fc4114a017db680e70151c086cc03fb
+size 551192

--- a/book/opmanual_duckietown/images/traffic_light_18/C-02.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/C-02.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f94b63471f7f0eb6a39f2804f981b79eb2aff212bc39fc5756f729a706102c6
+size 408113

--- a/book/opmanual_duckietown/images/traffic_light_18/G-1.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b9e3b3205e14394b4a8d206b013c8b246b80de73c0f98aed319f8ffa7b32b72
+size 1022981

--- a/book/opmanual_duckietown/images/traffic_light_18/G-2.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:532396768a5ae5305c9f6b1d93a4da6b0fe7da3ebc01c36bea47ea2c95e9b5d1
+size 324563

--- a/book/opmanual_duckietown/images/traffic_light_18/G-3.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dbfb30c8b2294420977eac48e658ea9116391e1f72489a1069c641367756642
+size 282207

--- a/book/opmanual_duckietown/images/traffic_light_18/G-4.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G-4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86e2f8bd2661b560dfc0cb9468630b6aca3dc61d16c4d63b3e4ccd59ba881ad6
+size 280525

--- a/book/opmanual_duckietown/images/traffic_light_18/G-5.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G-5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72e58323826c2be51a130349d36fd05c93b05ba5ef9a46ee226574d5d3a2bf89
+size 485501

--- a/book/opmanual_duckietown/images/traffic_light_18/G-6.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G-6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1706903b7b0b46a5fa3435f7712be1b809fa41b79e50289a959f69e8c69bd02
+size 253298

--- a/book/opmanual_duckietown/images/traffic_light_18/G-7.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G-7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f1aea8023fea450f04c8b46a555753016647684086fa94ba7278f0b7260ca2b
+size 227120

--- a/book/opmanual_duckietown/images/traffic_light_18/G-8.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G-8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2424cc163786be28f721d88309786d8a168fd4c4c9ef72d396e18d7ba780e071
+size 128814

--- a/book/opmanual_duckietown/images/traffic_light_18/G2-1.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G2-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8f2e92c44b95d7936eede4788b723dd4ae7d9cff1bfc60b1cd7104d3632d12d
+size 849064

--- a/book/opmanual_duckietown/images/traffic_light_18/G2-2.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G2-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd647e83f0c68ba1d30dd346180a16cc5f8332e96768df8e5e3704991d6270b7
+size 169423

--- a/book/opmanual_duckietown/images/traffic_light_18/G2-3.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G2-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1de9dddf252d348843187cdefb45a173d989b6dc95f773b56ec6c7fc758f50ff
+size 279143

--- a/book/opmanual_duckietown/images/traffic_light_18/G2-4.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G2-4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b9dc043828da7763dd68765decd1cfdd287182a3f8cb457883f37d3f83c519b
+size 176507

--- a/book/opmanual_duckietown/images/traffic_light_18/G2-5.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G2-5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41a112a2fb477cfaf5a3833410282ce43b2bfa2dd458e7612073fa1aa72c52fa
+size 435475

--- a/book/opmanual_duckietown/images/traffic_light_18/G2-6.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G2-6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a390c531d2bfaa62f676cee65c7e2e75152bc929d2cfd1f8fd4962779fe01f77
+size 441702

--- a/book/opmanual_duckietown/images/traffic_light_18/G2-7.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/G2-7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3afd52c08e07b176baa37f29b6726ce7b0b16410d909ae3f2d6381c43783a95
+size 322364

--- a/book/opmanual_duckietown/images/traffic_light_18/H-1.png
+++ b/book/opmanual_duckietown/images/traffic_light_18/H-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d8315d92be2153c5e589b850abc3c767f957e09da575509fcb1c345b0e1c74d
+size 1241984

--- a/book/opmanual_duckietown/images/traffic_light_18/J-1.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/J-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9062b1c47e2f039f90dd63d9d322ef7ee35136e518b96dd142f6d89b0a29a299
+size 550309

--- a/book/opmanual_duckietown/images/traffic_light_18/J-2.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/J-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:057d3e952955622af6a2fe7fcd3834837eb8e65e120bc762299d29c1f19b79c1
+size 239151

--- a/book/opmanual_duckietown/images/traffic_light_18/J-3.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/J-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af8845f362cece37db0b89834a93e0f42c27e9322c3887fadcc08079cf1b2bbe
+size 210684

--- a/book/opmanual_duckietown/images/traffic_light_18/J-4.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/J-4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:014649d6d30142eba92a394af1a7490806f5dce89c6c90c0813d6b93217380ca
+size 227786

--- a/book/opmanual_duckietown/images/traffic_light_18/J-5.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/J-5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3324ad07c543ef6b3d0bb35234feebeee6806559b8b91a7398e0e3e4456badd
+size 273025

--- a/book/opmanual_duckietown/images/traffic_light_18/J-6.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/J-6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e9c9ed20717cf5cb7708af8a31a91bf54380d037963cbe4224129eb1787b92
+size 264774

--- a/book/opmanual_duckietown/images/traffic_light_18/J-7.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/J-7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd8fed62875a0f680ac831661553efa00053a44819425b46de36034cab56762e
+size 308637

--- a/book/opmanual_duckietown/images/traffic_light_18/J-8.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/J-8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e6ccf53ae986dd08a965c3c847bb1d6b85445768df7c9e2d4b6e4f8e1fc852d
+size 298074

--- a/book/opmanual_duckietown/images/traffic_light_18/L-0.png
+++ b/book/opmanual_duckietown/images/traffic_light_18/L-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11e27cc99d565ec9ea9652ea392e80337c38e5fad3d6feb2ab3a1d41dd8c7e88
+size 682052

--- a/book/opmanual_duckietown/images/traffic_light_18/L-1.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/L-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecbc14e6528328a2e32c04ab2a86f4f159c3ff88199e80f6a9d2c20edb51da4c
+size 603795

--- a/book/opmanual_duckietown/images/traffic_light_18/L-2.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/L-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe3a345978124699a40df53adde171d7575e6f8647531489bf145e7e631e2f45
+size 152834

--- a/book/opmanual_duckietown/images/traffic_light_18/L-3.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/L-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:816c829c70427f6eed42b7d41f8793845bd9152841fa1012c419f7de01273fa3
+size 293819

--- a/book/opmanual_duckietown/images/traffic_light_18/L-4.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/L-4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:371f8f6e78060e8b313a3facda20479732164094a3183279dae811168acdb3a4
+size 151783

--- a/book/opmanual_duckietown/images/traffic_light_18/L-5.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/L-5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bed79f1263e4d0ac0a9cec2d1d98007fc9404708636ea19b7d447168d7fd12a3
+size 422363

--- a/book/opmanual_duckietown/images/traffic_light_18/L-6.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/L-6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a0e6df5e8ee45a6611dc7ab09b55fb1661242414d1480aa9adeded93e066ac1
+size 554044

--- a/book/opmanual_duckietown/images/traffic_light_18/STEP_18_cropped.png
+++ b/book/opmanual_duckietown/images/traffic_light_18/STEP_18_cropped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72b820bb3744fb0726a2cd21394b5a88c2c046cf2be2270e46e69ad8fe0d30b7
+size 247255

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-01.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-01.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c20d1c68fc10b4c92c6745f037e67f1a5da10bf074b9d19979e1d0baf60c460
+size 1869697

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-02.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-02.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66f8a67c80076d9b820e4a8eacd8eb010f900bcfd04991c26a41c8b459b79ff7
+size 1479000

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-03.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-03.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db4828da698174920fd7dcc6e99540c0e7943102460b6c76ab3f1a07060e2693
+size 1361023

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-04.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-04.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec2093c52355592b47b63c2df1906a09f8130c83d8e3538c972e58f836787004
+size 911851

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-05.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-05.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26a5ccacab1a892197b6a8504178f4786c3ddd27fadf5a09fe3960a0d551f44b
+size 362010

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-06.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-06.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23bef7a77e9a9469b3450abf1206448fa7985cccef583a1864c8b21ebec5a48e
+size 395165

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-07.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-07.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a2475ca839aeef9c4429c260ac804a22712de8d5c4fc2bd3a011a45b0430cc8
+size 1827880

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-08.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-08.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a691fa1bb8fe4b34571e3d8407325cc75e588e76f9fa0c09e2605a9fceaec1f
+size 1578164

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-09.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-09.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc61c6578f92106371f40c184eb22979d723fc314e9459c6e53dafce88c38bfa
+size 1049630

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-10.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-10.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5373c1ebe34f9b0e5ba62233d2f7673b79bf5dc793b0e88c282f1005786eab79
+size 640947

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-11.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-11.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9581874608aaf5f1ec51be65734780a97b815bd7db799640775738d8b2a843b
+size 1013416

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-12.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-12.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61233ad7d0934c88a8f95e68141edafcb071f951cf151f101a586d5478761672
+size 585518

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-13.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-13.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90fc9f4e8a5266f24d97e050ccc793dfbaf8687e6a843d70f9ad365d7837ed5
+size 756141

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-14.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-14.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a76b17970cab7d8aba36d6088d217561a70494b5b9a60eb9faefb45283851695
+size 1055986

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-15.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-15.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82746407ee1c1c9440d5434e651dfd1bf84e8fea4713e61195945b693c568ffa
+size 1520372

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-16.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-16.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12bcbc74adc28ccb8ac076eb5763737d7cb2fdf2dbcec1892d95602f6219c880
+size 2098267

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-17.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-17.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2636f5b6dec141c971504fd8e47048cff20a2f8b172ec18bb5161a737409af48
+size 1479773

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-18.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-18.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e85b558093f4fcc02c9987eb193c1c52d8821071356d009d288672fec98e64a
+size 2619286

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-19.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-19.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86fbf23254225f740bea571bef0745f561de1bd126173dc1d55b809bb3bec0f8
+size 2264740

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-20.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-20.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00bac1f78f8f524366ca950254b3e055c8836df8335bc32ac0b5f08f0cad6547
+size 672493

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-21.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-21.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2442e1c0632ea6804669707dd0218703c67100954db1a2033e1c9f674f7940e3
+size 2684630

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-22.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-22.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:747beed82badc59eef606d829d7d75ad77e08f26ddcff6ea237ef7c3b5401af4
+size 829789

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-23.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-23.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d1720780af49d048806ea515103a79057b100f6c03bac5f3f649aff068f022e
+size 1546808

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-24.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-24.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afbd7ce440eb389daffa821ccfe9d886ca15a6f46e690869ec005c3be06a1db5
+size 1453933

--- a/book/opmanual_duckietown/images/traffic_light_18/TL-25.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/TL-25.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b45a5a0123716c07d4ef4bb0f2cc73fe54b079eb8d743c4f05a19e2b4756d08
+size 1443393

--- a/book/opmanual_duckietown/images/traffic_light_18/c-01-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/c-01-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96ee47c6a18c1030e298ccc6028604f799d1d0ec43a1493e008b19d6885071fb
+size 72898

--- a/book/opmanual_duckietown/images/traffic_light_18/c-02-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/c-02-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f51aafc755f9c9c45fac855a119270571fe28c3182fa2a22398bd8d38a1d6f4
+size 84876

--- a/book/opmanual_duckietown/images/traffic_light_18/g-1-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g-1-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee0eccef5d753671d04fa5ae9133a3e11e0dcabd6084f4d5e530d22e37b2f011
+size 137886

--- a/book/opmanual_duckietown/images/traffic_light_18/g-2-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g-2-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a5e64ee892ccb3e6b8dabd3b2c480a10d8671ebcc5865ce7c1ede478e14148b
+size 117322

--- a/book/opmanual_duckietown/images/traffic_light_18/g-3-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g-3-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:336a43bce2e934562ec7841355368a7b93359a7abff541fed545a1f613d34737
+size 79669

--- a/book/opmanual_duckietown/images/traffic_light_18/g-4-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g-4-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc66c584072c144b078aa72343dfa7325354d424882ace93c31b5fcc07261782
+size 92364

--- a/book/opmanual_duckietown/images/traffic_light_18/g-5-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g-5-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52fca08e7acb15e3612e2f566bb576f29b4e0b7efd8abb49390ecc0564052661
+size 70110

--- a/book/opmanual_duckietown/images/traffic_light_18/g-6-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g-6-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86f41fcc0762d77d60e4ef6c1e3991e06468ce4d18ff01877dabace09952aca6
+size 89478

--- a/book/opmanual_duckietown/images/traffic_light_18/g-7-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g-7-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2485b24e0a830b4ca386c026f8c3d3c0160e56eb3870ff61385ab9bae30e1535
+size 74531

--- a/book/opmanual_duckietown/images/traffic_light_18/g2-1-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g2-1-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dff82d0488612cfe6df8017b8ede4db9aa7bffd52b0a396d2450d0edfed435c
+size 82128

--- a/book/opmanual_duckietown/images/traffic_light_18/g2-2-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g2-2-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6414f41d22b961fb931ab68189ccab32639417b4499c080e871588dbd97e9673
+size 67856

--- a/book/opmanual_duckietown/images/traffic_light_18/g2-3-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g2-3-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3b9feda9a681a6e24c18cc1f49d01c19b0622376e8ce34bc8553652ac64efcc
+size 86898

--- a/book/opmanual_duckietown/images/traffic_light_18/g2-4-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g2-4-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:936ace3a510a6cbb57aa3dbaa59c2963a76b61f98bbc49a1623977f891280cb3
+size 67812

--- a/book/opmanual_duckietown/images/traffic_light_18/g2-5-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g2-5-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cd4732ef0b230070a599c7225e955332df2eca552e3ddbdeab4d333da68da0e
+size 75204

--- a/book/opmanual_duckietown/images/traffic_light_18/g2-6-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g2-6-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:394135c09c18ac237a5006f60a17eaa870d9f8913ab5c377b19bcd03e47430c8
+size 118018

--- a/book/opmanual_duckietown/images/traffic_light_18/g2-7-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/g2-7-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc33a304c4747b9edbec616e7232cce482e5ad9c85e51abc631f2a053b0d3028
+size 117142

--- a/book/opmanual_duckietown/images/traffic_light_18/j-1-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/j-1-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e306ae83b37c94f374349f3297fc1fdaafa235059269fafb6d035f6ff16a4d6
+size 95122

--- a/book/opmanual_duckietown/images/traffic_light_18/j-2-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/j-2-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85d84f151abd63cd8633df18ebce40e6efa896a4ccd03715f890d6e682cf6f5c
+size 121787

--- a/book/opmanual_duckietown/images/traffic_light_18/j-3-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/j-3-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f5830e9b5e19cad13a7ab4a38e8fdfca1ab49b4074b3fb45e2b0ce71ba2a115
+size 64545

--- a/book/opmanual_duckietown/images/traffic_light_18/j-4-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/j-4-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:471c8a5a1052b4aa8a4e1dd3c084b24fbab49ea32973ac3e9561d411b3a1f202
+size 74988

--- a/book/opmanual_duckietown/images/traffic_light_18/j-5-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/j-5-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13f9e92112dcd535e581d641f15c94e80663511885813bfe64cbb4c9c83c107c
+size 71046

--- a/book/opmanual_duckietown/images/traffic_light_18/j-6-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/j-6-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65f1b29548a2f613b9df5719f87b09476d1cb6751cf29acd7ca2df420eeccf64
+size 83770

--- a/book/opmanual_duckietown/images/traffic_light_18/j-7-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/j-7-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:012fb28af92b6c662d4fbbd6ddf77d640dc133bc52c2ce081b020cb8cb3a40db
+size 64343

--- a/book/opmanual_duckietown/images/traffic_light_18/j-8-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/j-8-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96ab6c4ca0933415bc81266fbf12a1cabc107341d313f6837cdc4cd5a47df8f8
+size 87692

--- a/book/opmanual_duckietown/images/traffic_light_18/l-1-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/l-1-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d546baa4a94180a9fe4c82816fac2dca4d8d68adbdfd2e0d7e39d7fb40de7bdc
+size 158225

--- a/book/opmanual_duckietown/images/traffic_light_18/l-2-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/l-2-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c4d347c2cc0531317b29cc807c52bf6de1cd85e0a9126532ef14848ba9a006f
+size 76722

--- a/book/opmanual_duckietown/images/traffic_light_18/l-3-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/l-3-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9665cf071e50044c5fdf3461da12dce81eaa664004a724338a6d463220af6393
+size 92726

--- a/book/opmanual_duckietown/images/traffic_light_18/l-4-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/l-4-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d678a03a737f291f263820bc34d628735d0e4e2fa09bb0f14acc330ef20c2d62
+size 69578

--- a/book/opmanual_duckietown/images/traffic_light_18/l-5-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/l-5-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23fcb896f4d203ddc388db369d4060eaf740b4eb170ddef766e3b6a0285f749
+size 66144

--- a/book/opmanual_duckietown/images/traffic_light_18/l-6-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/l-6-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a9eaaf54655623ce28f605025eca362fad9f61c23a0e1c675ff8018e6a6cb0b
+size 127744

--- a/book/opmanual_duckietown/images/traffic_light_18/mooc-map-21.png
+++ b/book/opmanual_duckietown/images/traffic_light_18/mooc-map-21.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30d559de85494a10e5091c35cbe5f0b87963fb38227b7ff8ce90d26e23107698
+size 10732061

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-01-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-01-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5799f2161beb686e4a6219f37e3bb8fd83ebfb105411d678eb0d17efabc399c6
+size 148631

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-02-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-02-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1680157ef497e19fb8f12aae03ee9d188e94c9721d84af45ffb9b3b8de4bd3d
+size 116506

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-03-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-03-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:842c6442392ab6d488fafdfe4ac20146734b5c279c043422ce7d02219e9fea0b
+size 123797

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-04-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-04-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f5841e4cd14a3ef954d5758202dd41005ca1bc2311865b39fcaea973d33ada3
+size 135875

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-05-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-05-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bed68caffcdf12533921fa1bd67067d8b5d540f92c086531a7babcd691e6535a
+size 114463

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-06-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-06-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c0fd6609f7f4ff3e3ca26e79be2f21deb944964c92c07664540cd2add941be7
+size 94596

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-07-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-07-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4a115a43fbd7848dbe668549f4dfcbdca0bfb269dc8a6548994213afcdc1c53
+size 116086

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-08-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-08-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d05d9c00e95ba87447e8e2fdf908057f4844116637f58a2f8fdd32a3b15a8300
+size 90470

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-09-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-09-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2807b884f61e395c622c1901451ed5d60c35e218b95eaea66189b21bca372ddc
+size 71288

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-10-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-10-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3178bf898651c9f5546c459a973c1b7a446404867f35a6f43cbacaddd4cf5258
+size 113947

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-11-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-11-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d80637394fe04491d4f4a49ae7f1db6d10cde3cc1e90c70fdb00148f3a1babe1
+size 64435

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-12-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-12-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e681387840e6eb88b4848a7f3455ae507a3d91426d469561a6074a90d55c68e7
+size 40830

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-13-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-13-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:692360dd3eb520c1ecb0c8d59c446f6b36857c6af6abf6a513ea083ef009fc48
+size 45192

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-14-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-14-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1800bb9aedb325671e6c3eea325d7ab06dba719d0cd0257986203ccbd9c22088
+size 96582

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-15-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-15-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b851dbee9e407cc4982a796f34c8d3c822de6beb4f8f323e8975dd969f620286
+size 111239

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-16-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-16-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dc81957319015060b58bad175d0f8621930337ee89d8db086aba6d11d4391e8
+size 141845

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-17-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-17-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04cae11a0083015bbc854efd1d643c4a6c38eae472e49a5e274345d086b4f8fd
+size 87455

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-18-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-18-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:077789c205afc45d62dcabdf82109f0910af1ca0c00c00c7db03fd55c2945c44
+size 154465

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-19-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-19-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1ca571618ad547267c72a42ce44c7925c0d16ba6db770904063b89babf30bb3
+size 144523

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-20-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-20-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94a85e3fde2dce6b13abb6e6961fb20a0a4eee361e4e896155ad71664a897005
+size 83550

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-21-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-21-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e19ba8390b18a60c552a6f039bf2752866afd59d730b9f11d6012c241b28f69
+size 165637

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-22-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-22-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77cd6f90a11d8ead4ccf7f4811ad82154b510c50bdc6df2e64be3c37a8c1952e
+size 87006

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-23-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-23-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dd720b19e1c3b18b4d3dba5204168a0147044fb15b4ca1b1ccbf5e0674fd370
+size 122012

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-24-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-24-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58521a4905fdd3d6b2311ac8b25d3fa73be30abc21ec2362f029a514d5cec724
+size 122224

--- a/book/opmanual_duckietown/images/traffic_light_18/tl-25-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tl-25-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b7c282f7f2d0bfbea8b50e02ac5e4e68d652ff577910f14d47c82cbcbd21d70
+size 85685

--- a/book/opmanual_duckietown/images/traffic_light_18/tons-of-duckies-resized-1024.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tons-of-duckies-resized-1024.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7758d9e2c0e253ae40ad57506dc98d52b5f495bb94b40a0ad10db3858c4c603f
+size 101558

--- a/book/opmanual_duckietown/images/traffic_light_18/tons-of-duckies.jpg
+++ b/book/opmanual_duckietown/images/traffic_light_18/tons-of-duckies.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:674331181169be7dfd1eb31eea0465c9a706f030e168fa4bbe521f7eda0fce00
+size 7192064


### PR DESCRIPTION
- Distinguishing between dt1-tl and dt21-tl instructions
- reintroducing dt18-tl
- fixing hut connection photo on dt18-tl